### PR TITLE
Modified deduplication to re-send piggybacked responses

### DIFF
--- a/lib/src/coap_server.c
+++ b/lib/src/coap_server.c
@@ -1877,9 +1877,16 @@ static int coap_server_exchange(coap_server_t *server)
         {
             /* message deduplication */
             /* acknowledge the (confirmable) request again */
-            /* do not send the response again */
+            /* do not send the response again if it was not piggybacked */
             coap_log_info("Received duplicate confirmable request from address %s and port %u", trans->client_addr, ntohs(trans->client_sin.COAP_IPV_SIN_PORT));
-            ret = coap_server_trans_send_ack(trans, &recv_msg);
+            resp_type = coap_server_get_resp_type(server, &recv_msg);
+            if (resp_type == COAP_SERVER_SEPARATE) {
+                /* do not send the response again */
+                ret = coap_server_trans_send_ack(trans, &recv_msg);
+            } else {
+                /* re-send piggybacked response */
+                ret = coap_server_trans_send(trans, &trans->resp);
+            }
             coap_msg_destroy(&recv_msg);
             if (ret < 0)
             {


### PR DESCRIPTION
When a piggybacked message is lost, and a duplicate request arrives at the server, the server

> SHOULD acknowledge each duplicate copy of a Confirmable message using the same Acknowledgement

I agree that section 4.5. from the RFC leaves this open to discussion, because of the _SHOULD_ key word.

However, I feel that it's worth resending the ACK with the response, specially in the context of block-wise transfers.

Otherwise, without this modification, if a piggybacked response of a block is lost, then the entire block-wise transfer needs to be restarted because currently the server will only send an empty ACK, no response.

