### PR TITLE
Support for HTTP requests comming from, for example, cURL

### DIFF
--- a/proxy/common/src/http_msg.c
+++ b/proxy/common/src/http_msg.c
@@ -272,6 +272,14 @@ static ssize_t http_msg_parse_start(http_msg_t *msg, char *str)
 
     for (i = 0; i < HTTP_MSG_NUM_START; i++)
     {
+	/* 
+	 * Removing unnecessary '/' (e.g. when using cURL)
+	 */
+	if(*next == '/')
+	{
+	    next++;
+	}
+
         start = next;
         if (i < HTTP_MSG_NUM_START - 1)
         {
@@ -347,6 +355,16 @@ static ssize_t http_msg_parse_headers(http_msg_t *msg, char *str)
             return -EBADMSG;
         }
         *value++ = '\0';
+
+	/*
+	 * Skip 'Accept' header since it's not supported
+         * (common header in many HTTP applications)
+         */
+	if(strcmp("Accept", name) == 0)
+	{
+	    continue;
+	}
+
         ret = http_msg_list_add(&msg->header, http_msg_trim_ws(name), http_msg_trim_ws(value));
         if (ret < 0)
         {


### PR DESCRIPTION
The parsing from `http_msg.c` could not hand requests with an additional '/', as discussed in #18. 
Problems will also occur with simple Accept headers.

This PR provides a fix for such situations but a more comprehensive handling of headers may be desirable.