### PR TITLE
Pull Request: Improved Handshake Handling

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,5 +1,5 @@
 AUTOMAKE_OPTIONS = subdir-objects
-AM_CFLAGS = -I$(srcdir)/include -DCOAP_DTLS_EN
+AM_CFLAGS = -I$(srcdir)/include -DCOAP_DTLS_EN -DCOAP_CLIENT_AUTH
 lib_LTLIBRARIES = libfreecoap.la
 libfreecoap_la_SOURCES = src/coap_msg.c include/coap_msg.h src/coap_log.c include/coap_log.h src/coap_client.c include/coap_client.h src/coap_server.c include/coap_server.h include/coap_ipv.h src/coap_mem.c include/coap_mem.h
 libfreecoap_la_LDFLAGS = -version-info 0:5:0


### PR DESCRIPTION
### Overview
I have made changes to how handshakes are handled to address issues encountered during high traffic on the server. Previously, the server was too quick to reject handshakes from clients, causing problems.

### Issue
During high traffic, I discovered that on some occasions, the GNUTLS library would return **GNUTLS_E_AGAIN** but errno would also be set to something other than **EAGAIN**, resulting in handshake failures.

### Solution
To resolve this, I implemented a check to ensure we retry when GNUTLS indicates to do so. Additionally, I've added retries for the PUSH, PULL functions, and early termination failures due to high throughput on the server socket.

### Changes Made
Implemented retry logic when **GNUTLS_E_AGAIN** is returned, regardless of errno.
Added retry mechanisms for **PUSH**, **PULL** functions, and early termination scenarios.
Impact
These changes should improve the reliability of handshake processing, particularly under high server load.

_This version maintains the original intent while improving clarity and structure_.